### PR TITLE
refactor: remove deprecated substr

### DIFF
--- a/which-pm-runs/index.js
+++ b/which-pm-runs/index.js
@@ -11,7 +11,7 @@ function pmFromUserAgent (userAgent) {
   const pmSpec = userAgent.split(' ')[0]
   const separatorPos = pmSpec.lastIndexOf('/')
   return {
-    name: pmSpec.substr(0, separatorPos),
-    version: pmSpec.substr(separatorPos + 1)
+    name: pmSpec.substring(0, separatorPos),
+    version: pmSpec.substring(separatorPos + 1)
   }
 }


### PR DESCRIPTION
Hello, `String.prototype.substr()` is a deprecated function, maybe use `String.prototype.slice()` is better.

`String.prototype.substr()` is defined in [Annex B](https://262.ecma-international.org/9.0/#sec-string.prototype.substr) of the ECMA-262 standard. We can find [introduction](https://262.ecma-international.org/9.0/#sec-additional-ecmascript-features-for-web-browsers) like this: 
> These features are not considered part of the core ECMAScript language. Programmers should not use or assume the existence of these features and behaviours when writing new ECMAScript code.