### PR TITLE
fix(rename-overwrite): allow cross-filesystem rename

### DIFF
--- a/.changeset/clean-planes-act.md
+++ b/.changeset/clean-planes-act.md
@@ -1,0 +1,5 @@
+---
+"rename-overwrite": patch
+---
+
+Support moving files and directories across devices.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,7 @@ importers:
     specifiers:
       '@zkochan/rimraf': ^2.1.2
       fs-extra: ^10.1.0
+      jest: ^27.4.3
       load-json-file: 6.2.0
       rename-overwrite: 'link:'
       standard: ^16.0.4
@@ -303,6 +304,7 @@ importers:
       '@zkochan/rimraf': 2.1.2
       fs-extra: 10.1.0
     devDependencies:
+      jest: 27.5.1
       load-json-file: 6.2.0
       rename-overwrite: 'link:'
       standard: 16.0.4
@@ -5403,7 +5405,7 @@ packages:
       strip-bom: 3.0.0
 
   /locate-path/2.0.0:
-    resolution: {integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=}
+    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
     dependencies:
       p-locate: 2.0.0
@@ -6691,7 +6693,7 @@ packages:
       yocto-queue: 0.1.0
 
   /p-locate/2.0.0:
-    resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
+    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
     dependencies:
       p-limit: 1.3.0
@@ -6734,7 +6736,7 @@ packages:
     dev: false
 
   /p-try/1.0.0:
-    resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}
+    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
     dev: true
 
@@ -6833,7 +6835,7 @@ packages:
     dev: true
 
   /parse-json/4.0.0:
-    resolution: {integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=}
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
     engines: {node: '>=4'}
     dependencies:
       error-ex: 1.3.2
@@ -6867,7 +6869,7 @@ packages:
     dev: true
 
   /path-exists/3.0.0:
-    resolution: {integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=}
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
     dev: true
 
@@ -8787,6 +8789,7 @@ packages:
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
     dependencies:
       browser-process-hrtime: 1.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,6 @@ importers:
       rename-overwrite: 'link:'
       standard: ^16.0.4
       symlink-dir: ^5.0.1
-      tape: ^5.3.2
       tempy: ^1.0.1
       write-json-file: ^4.3.0
     dependencies:
@@ -309,7 +308,6 @@ importers:
       rename-overwrite: 'link:'
       standard: 16.0.4
       symlink-dir: 5.0.1
-      tape: 5.5.3
       tempy: 1.0.1
       write-json-file: 4.3.0
     dependenciesMeta:
@@ -3646,7 +3644,7 @@ packages:
     dev: true
 
   /find-up/1.1.2:
-    resolution: {integrity: sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=}
+    resolution: {integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       path-exists: 2.1.0
@@ -3654,7 +3652,7 @@ packages:
     dev: true
 
   /find-up/2.1.0:
-    resolution: {integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=}
+    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
     dependencies:
       locate-path: 2.0.0
@@ -5267,6 +5265,7 @@ packages:
     dependencies:
       chalk: 0.5.1
     dev: true
+    bundledDependencies: []
 
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
@@ -6862,7 +6861,7 @@ packages:
     dev: true
 
   /path-exists/2.1.0:
-    resolution: {integrity: sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=}
+    resolution: {integrity: sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       pinkie-promise: 2.0.1
@@ -7533,7 +7532,7 @@ packages:
     dev: true
 
   /retry/0.12.0:
-    resolution: {integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=}
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -8062,7 +8061,7 @@ packages:
       ansi-regex: 5.0.1
 
   /strip-bom/2.0.0:
-    resolution: {integrity: sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=}
+    resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-utf8: 0.2.1
@@ -8945,7 +8944,7 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /write-file-atomic/1.3.4:
-    resolution: {integrity: sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=}
+    resolution: {integrity: sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==}
     dependencies:
       graceful-fs: 4.2.10
       imurmurhash: 0.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,7 @@ importers:
   rename-overwrite:
     specifiers:
       '@zkochan/rimraf': ^2.1.2
-      fs-extra: ^10.1.0
+      fs-extra: 10.1.0
       jest: ^27.4.3
       load-json-file: 6.2.0
       rename-overwrite: 'link:'
@@ -5268,7 +5268,7 @@ packages:
     bundledDependencies: []
 
   /jsonfile/4.0.0:
-    resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.10
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,7 @@ importers:
   rename-overwrite:
     specifiers:
       '@zkochan/rimraf': ^2.1.2
+      fs-extra: ^10.1.0
       load-json-file: 6.2.0
       rename-overwrite: 'link:'
       standard: ^16.0.4
@@ -300,6 +301,7 @@ importers:
       write-json-file: ^4.3.0
     dependencies:
       '@zkochan/rimraf': 2.1.2
+      fs-extra: 10.1.0
     devDependencies:
       load-json-file: 6.2.0
       rename-overwrite: 'link:'
@@ -3740,6 +3742,15 @@ packages:
       pause-stream: 0.0.11
     dev: true
 
+  /fs-extra/10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: false
+
   /fs-extra/7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -5260,6 +5271,14 @@ packages:
     optionalDependencies:
       graceful-fs: 4.2.10
     dev: true
+
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
+    dev: false
 
   /jsonparse/1.3.1:
     resolution: {integrity: sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=}
@@ -8620,6 +8639,11 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
     dev: true
+
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
 
   /unpipe/1.0.0:
     resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}

--- a/rename-overwrite/index.js
+++ b/rename-overwrite/index.js
@@ -55,12 +55,12 @@ module.exports = async function renameOverwrite (oldPath, newPath, retry = 0) {
           await rimraf(newPath)
         } catch (rimrafErr) {
           if (rimrafErr.code !== 'ENOENT') {
-            throw rimrafErr;
+            throw rimrafErr
           }
         }
         await fs.promises.copyFile(oldPath, newPath)
         await rimraf(oldPath)
-        break;
+        break
       default:
         throw err
     }
@@ -91,12 +91,12 @@ module.exports.sync = function renameOverwriteSync (oldPath, newPath, retry = 0)
           rimraf.sync(newPath)
         } catch (rimrafErr) {
           if (rimrafErr.code !== 'ENOENT') {
-            throw rimrafErr;
+            throw rimrafErr
           }
         }
         fs.copyFileSync(oldPath, newPath)
         rimraf.sync(oldPath)
-        break;
+        break
       default:
         throw err
     }

--- a/rename-overwrite/index.js
+++ b/rename-overwrite/index.js
@@ -1,5 +1,7 @@
 'use strict'
 const fs = require('fs')
+const copySync = require('fs-extra/lib/copy/copy-sync')
+const copy = require('fs-extra/lib/copy/copy')
 const path = require('path')
 const rimraf = require('@zkochan/rimraf')
 
@@ -58,7 +60,7 @@ module.exports = async function renameOverwrite (oldPath, newPath, retry = 0) {
             throw rimrafErr
           }
         }
-        await fs.promises.copyFile(oldPath, newPath)
+        await copy(oldPath, newPath)
         await rimraf(oldPath)
         break
       default:
@@ -94,7 +96,7 @@ module.exports.sync = function renameOverwriteSync (oldPath, newPath, retry = 0)
             throw rimrafErr
           }
         }
-        fs.copyFileSync(oldPath, newPath)
+        copySync(oldPath, newPath)
         rimraf.sync(oldPath)
         break
       default:

--- a/rename-overwrite/index.js
+++ b/rename-overwrite/index.js
@@ -1,7 +1,8 @@
 'use strict'
 const fs = require('fs')
+const { promisify } = require('util')
 const copySync = require('fs-extra/lib/copy/copy-sync')
-const copy = require('fs-extra/lib/copy/copy')
+const copy = promisify(require('fs-extra/lib/copy/copy'))
 const path = require('path')
 const rimraf = require('@zkochan/rimraf')
 

--- a/rename-overwrite/package.json
+++ b/rename-overwrite/package.json
@@ -41,6 +41,7 @@
     "write-json-file": "^4.3.0"
   },
   "dependencies": {
-    "@zkochan/rimraf": "^2.1.2"
+    "@zkochan/rimraf": "^2.1.2",
+    "fs-extra": "^10.1.0"
   }
 }

--- a/rename-overwrite/package.json
+++ b/rename-overwrite/package.json
@@ -42,6 +42,6 @@
   },
   "dependencies": {
     "@zkochan/rimraf": "^2.1.2",
-    "fs-extra": "^10.1.0"
+    "fs-extra": "10.1.0"
   }
 }

--- a/rename-overwrite/package.json
+++ b/rename-overwrite/package.json
@@ -11,7 +11,7 @@
     "node": ">=12.10"
   },
   "scripts": {
-    "test": "standard && node test"
+    "test": "jest"
   },
   "repository": "https://github.com/zkochan/packages/tree/main/rename-overwrite",
   "keywords": [
@@ -32,11 +32,11 @@
     }
   },
   "devDependencies": {
+    "jest": "^27.4.3",
     "load-json-file": "6.2.0",
     "rename-overwrite": "link:",
     "standard": "^16.0.4",
     "symlink-dir": "^5.0.1",
-    "tape": "^5.3.2",
     "tempy": "^1.0.1",
     "write-json-file": "^4.3.0"
   },

--- a/rename-overwrite/test.js
+++ b/rename-overwrite/test.js
@@ -7,6 +7,18 @@ const renameOverwrite = require('rename-overwrite')
 const symlinkDir = require('symlink-dir')
 const tempy = require('tempy')
 
+jest.mock('fs', () => {
+  const fs = jest.requireActual('fs')
+  return {
+    ...fs,
+    renameSync: jest.fn(fs.renameSync),
+    promises: {
+      ...fs.promises,
+      rename: jest.fn(fs.promises.rename),
+    },
+  }
+})
+
 test('overwrite directory', async () => {
   process.chdir(tempy.directory())
 
@@ -16,6 +28,50 @@ test('overwrite directory', async () => {
   await renameOverwrite('1', '2')
 
   expect(loadJsonFile.sync('2/foo.json')).toBe(1)
+})
+
+describe('moving across devices synchronously', () => {
+  beforeAll(() => {
+    process.chdir(tempy.directory())
+
+    writeJsonFile.sync('1/foo.json', 1)
+    writeJsonFile.sync('2/foo.json', 2)
+
+    fs.renameSync.mockImplementation(() => {
+      throw Object.assign(new Error('EXDEV'), { code: 'EXDEV' })
+    })
+  })
+  afterAll(() => {
+    const { renameSync } = jest.requireActual('fs')
+    fs.renameSync.mockImplementation(renameSync)
+  })
+  it('should overwrite directory across devices', () => {
+    renameOverwrite.sync('1', '2')
+
+    expect(loadJsonFile.sync('2/foo.json')).toBe(1)
+  });
+})
+
+describe('moving across devices asynchronously', () => {
+  beforeAll(() => {
+    process.chdir(tempy.directory())
+
+    writeJsonFile.sync('1/foo.json', 1)
+    writeJsonFile.sync('2/foo.json', 2)
+
+    fs.promises.rename.mockImplementation(async () => {
+      throw Object.assign(new Error('EXDEV'), { code: 'EXDEV' })
+    })
+  })
+  afterAll(() => {
+    const { promises } = jest.requireActual('fs')
+    fs.promises.rename.mockImplementation(promises.rename)
+  })
+  it('should overwrite directory across devices', async () => {
+    await renameOverwrite('1', '2')
+
+    expect(loadJsonFile.sync('2/foo.json')).toBe(1)
+  });
 })
 
 test('overwrite file', async () => {

--- a/rename-overwrite/test.js
+++ b/rename-overwrite/test.js
@@ -1,14 +1,13 @@
 'use strict'
 const fs = require('fs')
 const path = require('path')
-const test = require('tape')
 const writeJsonFile = require('write-json-file')
 const loadJsonFile = require('load-json-file')
 const renameOverwrite = require('rename-overwrite')
 const symlinkDir = require('symlink-dir')
 const tempy = require('tempy')
 
-test('overwrite directory', async t => {
+test('overwrite directory', async () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('1/foo.json', 1)
@@ -16,11 +15,10 @@ test('overwrite directory', async t => {
 
   await renameOverwrite('1', '2')
 
-  t.equal(loadJsonFile.sync('2/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('2/foo.json')).toBe(1)
 })
 
-test('overwrite file', async t => {
+test('overwrite file', async () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('1.json', 1)
@@ -28,33 +26,30 @@ test('overwrite file', async t => {
 
   await renameOverwrite('1.json', '2.json')
 
-  t.equal(loadJsonFile.sync('2.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('2.json')).toBe(1)
 })
 
-test('rename file when no overwrite is needed', async t => {
+test('rename file when no overwrite is needed', async () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('1.json', 1)
 
   await renameOverwrite('1.json', '2.json')
 
-  t.equal(loadJsonFile.sync('2.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('2.json')).toBe(1)
 })
 
-test('rename directory when no overwrite is needed', async t => {
+test('rename directory when no overwrite is needed', async () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('dir/foo.json', 1)
 
   await renameOverwrite('dir', 'newdir')
 
-  t.equal(loadJsonFile.sync('newdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/foo.json')).toBe(1)
 })
 
-test('sync overwrite directory', t => {
+test('sync overwrite directory', () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('1/foo.json', 1)
@@ -62,11 +57,10 @@ test('sync overwrite directory', t => {
 
   renameOverwrite.sync('1', '2')
 
-  t.equal(loadJsonFile.sync('2/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('2/foo.json')).toBe(1)
 })
 
-test('sync overwrite file', t => {
+test('sync overwrite file', () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('1.json', 1)
@@ -74,55 +68,50 @@ test('sync overwrite file', t => {
 
   renameOverwrite.sync('1.json', '2.json')
 
-  t.equal(loadJsonFile.sync('2.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('2.json')).toBe(1)
 })
 
-test('sync rename file when no overwrite is needed', t => {
+test('sync rename file when no overwrite is needed', () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('1.json', 1)
 
   renameOverwrite.sync('1.json', '2.json')
 
-  t.equal(loadJsonFile.sync('2.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('2.json')).toBe(1)
 })
 
-test('sync rename directory when no overwrite is needed', t => {
+test('sync rename directory when no overwrite is needed', () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('dir/foo.json', 1)
 
   renameOverwrite.sync('dir', 'newdir')
 
-  t.equal(loadJsonFile.sync('newdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/foo.json')).toBe(1)
 })
 
-test('create target directory, if it does not exist', async t => {
+test('create target directory, if it does not exist', async () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('dir/foo.json', 1)
 
   await renameOverwrite('dir', 'newdir/subdir')
 
-  t.equal(loadJsonFile.sync('newdir/subdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/subdir/foo.json')).toBe(1)
 })
 
-test('sync create target directory, if it does not exist', t => {
+test('sync create target directory, if it does not exist', () => {
   process.chdir(tempy.directory())
 
   writeJsonFile.sync('dir/foo.json', 1)
 
   renameOverwrite.sync('dir', 'newdir/subdir')
 
-  t.equal(loadJsonFile.sync('newdir/subdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/subdir/foo.json')).toBe(1)
 })
 
-test('overwrite a symlink', async t => {
+test('overwrite a symlink', async () => {
   process.chdir(tempy.directory())
 
   fs.mkdirSync('target')
@@ -130,11 +119,10 @@ test('overwrite a symlink', async t => {
   writeJsonFile.sync('dir/foo.json', 1)
 
   await renameOverwrite('dir', 'newdir')
-  t.equal(loadJsonFile.sync('newdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/foo.json')).toBe(1)
 })
 
-test('sync overwrite a symlink', async t => {
+test('sync overwrite a symlink', async () => {
   process.chdir(tempy.directory())
 
   fs.mkdirSync('target')
@@ -142,28 +130,25 @@ test('sync overwrite a symlink', async t => {
   writeJsonFile.sync('dir/foo.json', 1)
 
   renameOverwrite.sync('dir', 'newdir')
-  t.equal(loadJsonFile.sync('newdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/foo.json')).toBe(1)
 })
 
-test('overwrite a broken symlink', async t => {
+test('overwrite a broken symlink', async () => {
   process.chdir(tempy.directory())
 
   await symlinkDir(path.resolve('target'), 'newdir')
   writeJsonFile.sync('dir/foo.json', 1)
 
   await renameOverwrite('dir', 'newdir')
-  t.equal(loadJsonFile.sync('newdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/foo.json')).toBe(1)
 })
 
-test('sync overwrite a broken symlink', async t => {
+test('sync overwrite a broken symlink', async () => {
   process.chdir(tempy.directory())
 
   await symlinkDir(path.resolve('target'), 'newdir')
   writeJsonFile.sync('dir/foo.json', 1)
 
   renameOverwrite.sync('dir', 'newdir')
-  t.equal(loadJsonFile.sync('newdir/foo.json'), 1)
-  t.end()
+  expect(loadJsonFile.sync('newdir/foo.json')).toBe(1)
 })


### PR DESCRIPTION
Fixes issues like this:
- https://github.com/pnpm/pnpm/issues/5474
- https://github.com/pnpm/pnpm/issues/5318
- https://github.com/pnpm/pnpm/issues/4149
- https://github.com/pnpm/pnpm/issues/3848

Can manually test with `renameOverwrite('/home/<user>/somefile.json', '/tmp/somefile.json')`. Given you need to cross partitions, I'm not sure anything reliable can go into `test.js`.