### PR TITLE
feat(write-yaml-file): migrate js-yaml to yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
       "@types/node": "14.14.6"
     },
     "onlyBuiltDependencies": []
-  }
+  },
+  "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,12 +664,12 @@ importers:
 
   write-yaml-file:
     dependencies:
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
       write-file-atomic:
         specifier: ^5.0.1
         version: 5.0.1
+      yaml:
+        specifier: ^2.4.5
+        version: 2.4.5
     devDependencies:
       standard:
         specifier: ^16.0.4
@@ -5106,6 +5106,11 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.4.5:
+    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
+    engines: {node: '>= 14'}
+    hasBin: true
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -10404,6 +10409,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.4.5: {}
 
   yargs-parser@20.2.9: {}
 

--- a/write-yaml-file/README.md
+++ b/write-yaml-file/README.md
@@ -30,7 +30,7 @@ Returns a promise.
 
 #### `options`
 
-Same options that can be passed in to [js-yaml](https://www.npmjs.com/package/js-yaml#safedump-object---options-)
+Same options that can be passed in to [yaml](https://eemeli.org/yaml#tostring-options)
 
 ##### mode
 

--- a/write-yaml-file/index.js
+++ b/write-yaml-file/index.js
@@ -2,7 +2,7 @@
 const path = require('path')
 const fs = require('fs')
 const writeFileAtomic = require('write-file-atomic')
-const YAML = require('js-yaml')
+const YAML = require('yaml')
 
 const main = (fn, fp, data, opts) => {
   if (!fp) {
@@ -15,7 +15,7 @@ const main = (fn, fp, data, opts) => {
 
   opts = opts || {}
 
-  const yaml = YAML.dump(data, opts)
+  const yaml = YAML.stringify(data, opts)
 
   return fn(fp, yaml, { mode: opts.mode })
 }

--- a/write-yaml-file/package.json
+++ b/write-yaml-file/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://github.com/zkochan/packages/tree/main/write-yaml-file#readme",
   "dependencies": {
-    "js-yaml": "^4.1.0",
+    "yaml": "^2.4.5",
     "write-file-atomic": "^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
[yaml](https://eemeli.org/yaml) is a better library, and handles comments much better than js-yaml, which is no longer maintained, since ~3 years now.

This might possibly be a breaking change, as yaml accepts slightly different options.