### PR TITLE
refactor(which-pm): simplify yaml loading

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,9 +553,9 @@ importers:
 
   which-pm:
     dependencies:
-      load-yaml-file:
-        specifier: ^0.2.0
-        version: 0.2.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       standard:
         specifier: ^16.0.4

--- a/which-pm/index.js
+++ b/which-pm/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const path = require('path')
 const fs = require('fs')
-const loadYamlFile = require('load-yaml-file')
+const yaml = require('js-yaml')
 
 module.exports = async function (pkgPath) {
   const modulesPath = path.join(pkgPath, 'node_modules')
@@ -9,7 +9,8 @@ module.exports = async function (pkgPath) {
   if (exists) return { name: 'yarn' }
 
   try {
-    const modules = await loadYamlFile(path.join(modulesPath, '.modules.yaml'))
+    const modulesYaml = fs.readFileSync(path.join(modulesPath, '.modules.yaml'), 'utf8')
+    const modules = yaml.load(modulesYaml)
     return toNameAndVersion(modules.packageManager)
   } catch (err) {
     if (err.code !== 'ENOENT') throw err

--- a/which-pm/package.json
+++ b/which-pm/package.json
@@ -32,7 +32,7 @@
     }
   },
   "dependencies": {
-    "load-yaml-file": "^0.2.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "standard": "^16.0.4",


### PR DESCRIPTION
Use fs api and `js-yaml` directly to load yaml file instead of `load-yaml-file` package. The difference switching to this is:

1. `strip-bom` is no longer called. In my tests, having the BOM didn't really affect yaml parsing and it worked fine as before.
2. Upgraded `js-yaml` v3 to v4. The migration guide is [here](https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md). The main difference is that the [`safeLoad` API](https://github.com/LinusU/load-yaml-file/blob/d3e4568e0721591b4df1c4649a4920ec0c2d02b0/index.js#L8) is renamed to `load`

NOTE: I also noticed that we could use `read-yaml-file` from this monorepo, but I feel like using fs + `js-yaml` directly is simpler.