### PR TITLE
chore: fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,19 @@ jobs:
 
     steps:
     - name: Checkout Commit
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Setup Node
-      uses: actions/setup-node@v1
+      if: matrix.platform != 'macos-latest' || (matrix.node != '12' && matrix.node != '14')
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
+    # https://github.com/actions/setup-node/issues/1017
+    - name: Setup Node (macos, node<=14)
+      if: matrix.platform == 'macos-latest' && (matrix.node == '12' || matrix.node == '14')
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node }}
+        architecture: 'x64'
     - name: checkout main
       run: git branch -f main origin/main
     - name: Install pnpm
@@ -40,4 +48,4 @@ jobs:
     - name: Compile
       run: pnpm -r run prepublishOnly
     - name: run tests
-      run: pnpm -r --no-bail test
+      run: pnpm run test-all

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
+  "scripts": {
+    "test-all": "node test-all.js"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.27.6",
+    "semver": "^7.6.3",
     "typescript": "^4.5.2"
   },
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.6
         version: 2.27.6
+      semver:
+        specifier: ^7.6.3
+        version: 7.6.3
       typescript:
         specifier: ^4.5.2
         version: 4.6.4
@@ -4362,8 +4365,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.6.2:
-    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5351,7 +5354,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.2
+      semver: 7.6.3
 
   '@changesets/assemble-release-plan@6.0.2':
     dependencies:
@@ -5361,7 +5364,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.2
+      semver: 7.6.3
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -5398,7 +5401,7 @@ snapshots:
       p-limit: 2.3.0
       preferred-pm: 3.1.3
       resolve-from: 5.0.0
-      semver: 7.6.2
+      semver: 7.6.3
       spawndamnit: 2.0.0
       term-size: 2.2.1
 
@@ -5422,7 +5425,7 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.6.2
+      semver: 7.6.3
 
   '@changesets/get-release-plan@4.0.2':
     dependencies:
@@ -5720,7 +5723,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.3.7
+      semver: 7.6.3
 
   '@npmcli/git@2.1.0':
     dependencies:
@@ -5730,7 +5733,7 @@ snapshots:
       npm-pick-manifest: 6.1.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.3.7
+      semver: 7.6.3
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -7046,7 +7049,7 @@ snapshots:
       optionator: 0.9.1
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.6.3
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.0
@@ -8081,7 +8084,7 @@ snapshots:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.3.7
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8726,7 +8729,7 @@ snapshots:
       npmlog: 4.1.2
       request: 2.88.2
       rimraf: 3.0.2
-      semver: 7.3.7
+      semver: 7.6.3
       tar: 6.1.11
       which: 2.0.2
 
@@ -8765,14 +8768,14 @@ snapshots:
 
   npm-install-checks@4.0.0:
     dependencies:
-      semver: 7.3.7
+      semver: 7.6.3
 
   npm-normalize-package-bin@1.0.1: {}
 
   npm-package-arg@8.1.5:
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.3.7
+      semver: 7.6.3
       validate-npm-package-name: 3.0.0
 
   npm-packlist@2.2.2:
@@ -8787,7 +8790,7 @@ snapshots:
       npm-install-checks: 4.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 8.1.5
-      semver: 7.3.7
+      semver: 7.6.3
 
   npm-registry-fetch@11.0.0:
     dependencies:
@@ -9573,7 +9576,7 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.6.2: {}
+  semver@7.6.3: {}
 
   set-blocking@2.0.0: {}
 

--- a/test-all.js
+++ b/test-all.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const cp = require('child_process')
+const semverSatisfies = require('semver/functions/satisfies')
+
+// Run package tests that only matches the current node version via `engines.node`
+
+const nodeVersion = process.version.slice(1)
+const filteredPackageNames = []
+
+const files = fs.readdirSync(__dirname)
+for (const file of files) {
+  try {
+    const pkg = require(`./${file}/package.json`)
+    if (pkg.engines?.node) {
+      if (semverSatisfies(nodeVersion, pkg.engines.node)) {
+        filteredPackageNames.push(pkg.name)
+      } else {
+        console.log(`Skipping ${pkg.name} because it requires node ${pkg.engines.node}`)
+      }
+    } else {
+      filteredPackageNames.push(pkg.name)
+    }
+  } catch {}
+}
+
+cp.spawnSync(
+  'pnpm',
+  [
+    ...filteredPackageNames.map((name) => `--filter=${name}`),
+    '--no-bail',
+    'test'
+  ],
+  { stdio: 'inherit' }
+)


### PR DESCRIPTION
- Ensures test only run if the node version matches from `engines.node`
- Workaround macos and node<=14 fail: https://github.com/zkochan/packages/actions/runs/10646342816/job/29513071971?pr=201