### PR TITLE
fix(rename-overwrite): handle EBUSY error code

### DIFF
--- a/rename-overwrite/index.js
+++ b/rename-overwrite/index.js
@@ -19,12 +19,13 @@ module.exports = async function renameOverwrite (oldPath, newPath, retry = 0) {
         break
       // Windows Antivirus issues
       case 'EPERM':
-      case 'EACCESS': {
+      case 'EACCESS':
+      case 'EBUSY': {
         await rimraf(newPath)
         const start = Date.now()
         let backoff = 0
         let lastError = err
-        while (Date.now() - start < 60000 && (lastError.code === 'EPERM' || lastError.code === 'EACCESS')) {
+        while (Date.now() - start < 60000 && (lastError.code === 'EPERM' || lastError.code === 'EACCESS' || lastError.code === 'EBUSY')) {
           await new Promise(resolve => setTimeout(resolve, backoff))
           try {
             await fs.promises.rename(oldPath, newPath)
@@ -77,12 +78,13 @@ module.exports.sync = function renameOverwriteSync (oldPath, newPath, retry = 0)
     switch (err.code) {
       // Windows Antivirus issues
       case 'EPERM':
-      case 'EACCESS': {
+      case 'EACCESS':
+      case 'EBUSY': {
         rimraf.sync(newPath)
         const start = Date.now()
         let backoff = 0
         let lastError = err
-        while (Date.now() - start < 60000 && (lastError.code === 'EPERM' || lastError.code === 'EACCESS')) {
+        while (Date.now() - start < 60000 && (lastError.code === 'EPERM' || lastError.code === 'EACCESS' || lastError.code === 'EBUSY')) {
           const waitUntil = Date.now() + backoff
           while (waitUntil > Date.now()) {}
           try {


### PR DESCRIPTION
When using rename-overwrite in Windows, EBUSY might be raised by the underlying OS which should trigger a retry the same way it is done for EACCESS/EPERM.

**Context:**

We're using pnpm on a large project and getting EBUSY error on CI (GitLab, Windows Server runners).

We traced back the problem to the call to `renameOverwrite` from the [sync](https://github.com/pnpm/symlink-dir/blob/main/src/index.ts#L197) or [async](https://github.com/pnpm/symlink-dir/blob/main/src/index.ts#L92) versions of `forceSymlink` in the symlink-dir library.

A similar [issue](https://github.com/pnpm/pnpm/issues/6201) has already been solved in pnpm.
