### PR TITLE
fix(preferred-pm): detect pnpm via pnpm-workspace.yaml

### DIFF
--- a/.changeset/preferred-pm-detect-pnpm-workspace.md
+++ b/.changeset/preferred-pm-detect-pnpm-workspace.md
@@ -1,0 +1,5 @@
+---
+"preferred-pm": patch
+---
+
+Detect pnpm inside a pnpm workspace via `pnpm-workspace.yaml`, not only `pnpm-lock.yaml`. The README already documents that pnpm is preferred inside a pnpm workspace, but the lookup only searched for `pnpm-lock.yaml`. Repositories that set `lockfile: false` (no committed lockfile) were therefore not detected as pnpm projects. The directory walk now also looks for `pnpm-workspace.yaml`, which pnpm v10+ requires for workspace/config. Fixes #197.

--- a/preferred-pm/index.js
+++ b/preferred-pm/index.js
@@ -38,7 +38,7 @@ export async function preferredPM (pkgPath) {
     }
   }
   const { findUp } = await import('find-up-simple')
-  if (await findUp('pnpm-lock.yaml', { cwd: pkgPath })) {
+  if (await findUp('pnpm-lock.yaml', { cwd: pkgPath }) || await findUp('pnpm-workspace.yaml', { cwd: pkgPath })) {
     return {
       name: 'pnpm',
       version: '>=3'

--- a/preferred-pm/test/index.js
+++ b/preferred-pm/test/index.js
@@ -26,7 +26,11 @@ test('prefer pnpm', async () => {
 })
 
 test('prefer pnpm inside a pnpm workspace', async () => {
-  const pm = await preferredPM(path.join(__dirname, 'pnpm-workspace/packages/pkg'))
+  // Copy the fixture out of this repo so the lookup can't climb up to the
+  // monorepo's own pnpm-lock.yaml: detection must come from pnpm-workspace.yaml.
+  const dir = temporaryDirectory()
+  await ncp(path.join(__dirname, 'pnpm-workspace'), dir)
+  const pm = await preferredPM(path.join(dir, 'packages/pkg'))
   assert.deepStrictEqual(pm, { name: 'pnpm', version: '>=3' })
 })
 


### PR DESCRIPTION
Fixes #197.

## Problem

The README states *"Inside a pnpm workspace, pnpm is preferred"*, but the directory walk only searched for `pnpm-lock.yaml`:

```js
if (await findUp('pnpm-lock.yaml', { cwd: pkgPath })) { ... }
```

A pnpm workspace is defined by `pnpm-workspace.yaml`, and committing a lockfile is optional — repos can set `lockfile: false`. Such a project is **not** detected as pnpm. This bites tools built on `preferred-pm`: `@pnpm/prepare-package` does `const pm = (await preferredPM(gitRootDir))?.name ?? 'npm'`, so when it prepares a git-hosted dependency that is a lockfile-less pnpm project, it falls back to **npm** — which then honours that project's `.npmrc` `ignore-scripts=true` and skips the `prepare`/build, leaving no `dist/`.

As #197 notes, the existing `prefer pnpm inside a pnpm workspace` test only passes because it runs *inside this monorepo*, so `findUp('pnpm-lock.yaml')` climbs up and finds the monorepo's own lockfile — the fixture's `pnpm-workspace.yaml` is never consulted. Delete the monorepo lockfile and the test fails.

## Change

- `index.js`: the directory walk also looks for `pnpm-workspace.yaml`, matching the documented behaviour and pnpm v10+ (where `pnpm-workspace.yaml` is required for workspace/config).
- `test/index.js`: the `prefer pnpm inside a pnpm workspace` test now copies the fixture to a temp dir (same pattern as the Yarn/npm workspace tests) so detection must come from the fixture's `pnpm-workspace.yaml`, not an ancestor lockfile. Verified it fails without the `index.js` change and passes with it.

All 11 tests pass and `standard` is clean.