### PR TITLE
chore: add yaml package support metadata

### DIFF
--- a/read-yaml-file/package.json
+++ b/read-yaml-file/package.json
@@ -15,6 +15,10 @@
     "email": "z@kochan.io"
   },
   "repository": "https://github.com/zkochan/packages/tree/main/read-yaml-file",
+  "homepage": "https://github.com/zkochan/packages/tree/main/read-yaml-file#readme",
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  },
   "engines": {
     "node": ">=22.13"
   },

--- a/write-yaml-file/package.json
+++ b/write-yaml-file/package.json
@@ -34,6 +34,9 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/zkochan/packages/tree/main/write-yaml-file#readme",
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  },
   "dependencies": {
     "js-yaml": "catalog:",
     "write-file-atomic": "catalog:"


### PR DESCRIPTION
## Summary
- add npm `homepage` and `bugs.url` metadata for `read-yaml-file`
- add npm `bugs.url` metadata for `write-yaml-file`
- keep runtime code, dependencies, versions, entry points, and package files unchanged

## Validation
- metadata assertion for both package manifests
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --dir read-yaml-file test`
- `pnpm --dir write-yaml-file test`
- `npm pack --dry-run --json ./read-yaml-file`
- `npm pack --dry-run --json ./write-yaml-file`
- `git diff --check`
