### PR TITLE
Add missing bugs field to write-yaml-file

### DIFF
--- a/write-yaml-file/package.json
+++ b/write-yaml-file/package.json
@@ -34,14 +34,14 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/zkochan/packages/tree/main/write-yaml-file#readme",
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  },
   "dependencies": {
     "js-yaml": "catalog:",
     "write-file-atomic": "catalog:"
   },
   "devDependencies": {
     "standard": "catalog:"
-  },
-  "bugs": {
-    "url": "https://github.com/zkochan/packages/issues"
   }
 }

--- a/write-yaml-file/package.json
+++ b/write-yaml-file/package.json
@@ -40,5 +40,8 @@
   },
   "devDependencies": {
     "standard": "catalog:"
+  },
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
   }
 }


### PR DESCRIPTION
This adds the bugs field as requested in charles-openclaw/charles-microbounties#1605. The package.json was missing the issue tracker URL.