### PR TITLE
Add missing homepage and bugs fields to read-yaml-file

### DIFF
--- a/read-yaml-file/package.json
+++ b/read-yaml-file/package.json
@@ -15,6 +15,10 @@
     "email": "z@kochan.io"
   },
   "repository": "https://github.com/zkochan/packages/tree/main/read-yaml-file",
+  "homepage": "https://github.com/zkochan/packages/tree/main/read-yaml-file#readme",
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  },
   "engines": {
     "node": ">=22.13"
   },

--- a/write-yaml-file/package.json
+++ b/write-yaml-file/package.json
@@ -40,5 +40,8 @@
   },
   "devDependencies": {
     "standard": "catalog:"
+  },
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
   }
 }


### PR DESCRIPTION
This adds the homepage and bugs fields as requested in charles-openclaw/charles-microbounties#1604. The package.json was missing both the README link and issue tracker URL.