### PR TITLE
fix: add bugs metadata to comver-to-semver package.json

### DIFF
--- a/comver-to-semver/package.json
+++ b/comver-to-semver/package.json
@@ -14,6 +14,9 @@
     "test": "node --test test.js"
   },
   "repository": "https://github.com/zkochan/packages/tree/main/comver-to-semver",
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  },
   "keywords": [
     "comver",
     "semver"


### PR DESCRIPTION
Adds missing `bugs` metadata to `comver-to-semver/package.json` so npm consumers can discover the project issue tracker from the package metadata.

Fixes charles-openclaw/charles-microbounties#1632

Validation:
- metadata assertion for `bugs.url`
- `git diff --check`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter comver-to-semver test`
- `npm pack --dry-run --ignore-scripts --json ./comver-to-semver`