### PR TITLE
chore: add npm bugs and homepage metadata

### DIFF
--- a/comver-to-semver/package.json
+++ b/comver-to-semver/package.json
@@ -24,5 +24,8 @@
   "author": "Zoltan Kochan <z@kochan.io> (https://www.kochan.io/)",
   "license": "MIT",
   "homepage": "https://github.com/zkochan/packages/tree/main/comver-to-semver#readme",
-  "devDependencies": {}
+  "devDependencies": {},
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  }
 }

--- a/read-yaml-file/package.json
+++ b/read-yaml-file/package.json
@@ -31,5 +31,9 @@
   },
   "devDependencies": {
     "standard": "catalog:"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
+  },
+  "homepage": "https://github.com/zkochan/packages/tree/main/read-yaml-file#readme"
 }

--- a/write-yaml-file/package.json
+++ b/write-yaml-file/package.json
@@ -40,5 +40,8 @@
   },
   "devDependencies": {
     "standard": "catalog:"
+  },
+  "bugs": {
+    "url": "https://github.com/zkochan/packages/issues"
   }
 }


### PR DESCRIPTION
Adds missing bugs.url (and homepage for read-yaml-file) fields to package.json for comver-to-semver, write-yaml-file, and read-yaml-file so npm users can navigate to the issue tracker directly from the package metadata page.